### PR TITLE
Turn spaces in tags into underscores

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ class SwaggerResponse<T> {
 function apis(client, fn) {
   for (const [tag, { operations }] of Object.entries(client.apis)) {
     if (operations) {
-      fn(tag, operations);
+      fn(tag.replace(/\s+/g, '_'), operations);
     }
   }
 }

--- a/tests/pets.json
+++ b/tests/pets.json
@@ -23,7 +23,7 @@
       "get": {
         "summary": "List all pets",
         "tags": [
-          "pets"
+          "pets tag"
         ],
         "responses": {
           "200": {


### PR DESCRIPTION
I don't know if it's legal to have spaces in tags, but `@gasbuddy/configured-swagger-client` turns spaces into underscores in tagnames
eg: `pets tag` becomes `pets_tag`

This PR applies underscore replacement for spaces in tagnames